### PR TITLE
Correct error thrown by workflow. At runtime this error is thrown:

### DIFF
--- a/.github/workflows/check-references.yml
+++ b/.github/workflows/check-references.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Run reference check
         run: |
           pip install --upgrade pip
-          python scripts/check_doc_references.py
+          python ./scripts/check_doc_references.py


### PR DESCRIPTION
Correct failing workflow. Issue created in 23eb4183878324d8c1cc19d2686f9a99e0298606

Signed-off-by: Lucas Gonze <lucas@gonze.com>

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(docussaurus): spanish content configuration" or "feat(docker) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->
Commit 23eb4183878324d8c1cc19d2686f9a99e0298606 fails at runtime.

Run pip install --upgrade pip
Requirement already satisfied: pip in /opt/hostedtoolcache/Python/3.13.2/x64/lib/python3.13/site-packages (25.0.1)
python: can't open file '/home/runner/work/magma-documentation/magma-documentation/scripts/check_doc_references.py': [Errno 2] No such file or directory

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->
Running it in the CI is the only way to be sure

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    Is any action necessary to upgrade an existing instance other than restarting?
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

Relative path in original commit could have been used as a shim to force a privilege escalation

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

