### PR TITLE
Update quick_start_guide.md

### DIFF
--- a/docusaurus/versioned_docs/version-1.8.0/basics/quick_start_guide.md
+++ b/docusaurus/versioned_docs/version-1.8.0/basics/quick_start_guide.md
@@ -77,7 +77,7 @@ We will kick off the initial build of the AGW from source here.
 ```bash
 HOST [magma/lte/gateway]$ vagrant ssh magma
 MAGMA-VM [/home/vagrant]$ cd magma/lte/gateway
-MAGMA-VM [/home/vagrant/magma/lte/gateway]$ make run
+MAGMA-VM [/home/vagrant/magma/lte/gateway]$ bazel build
 ```
 
 **Note**: If you encounter unexpected errors during this process, try running


### PR DESCRIPTION
Changing from `$make run` to `$bazel build` after encountering this issue `As part of the Make to Bazel switch-over of the AGW this Makefile will be deprecated soon" message.`

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(docussaurus): spanish content configuration" or "feat(docker) ..."
-->

## Summary

On running `$ make run` I got the message: `MAIN_FEATURE agw_of
   OAI_FLAGS -DS6A_OVER_GRPC=True -DEMBEDDED_SGW=True
Warning: As part of the Make to Bazel switch-over of the AGW this Makefile
will be deprecated soon, see https://github.com/magma/magma/issues/14971.
Do not add any new Make targets for the AGW!
All new targets should be integrated with the Bazel build system, see https://magma.github.io/magma/docs/next/bazel/agw_with_bazel.` 

and a subsequent build failure.

## Test Plan

I initially encountered permission issues so I first did the following(Not recommended for everyone):
`$ sudo mkdir -p /var/cache/bazel-cache`
`$ sudo chown -R vagrant:vagrant /var/cache/bazel-cache`

Also do the same for the repository cache:

`$ sudo mkdir -p /var/cache/bazel-cache-repo`
`$ sudo chown -R vagrant:vagrant /var/cache/bazel-cache-repo`
`$ cd /home/vagrant/magma/lte/gateway`
`$ bazel build`

Result `INFO: Build completed successfully, 1 total action`


## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    Is any action necessary to upgrade an existing instance other than restarting?
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

