### PR TITLE
fix: set baseUrl for GitHub Pages project site

### DIFF
--- a/docusaurus/docusaurus.config.js
+++ b/docusaurus/docusaurus.config.js
@@ -19,7 +19,7 @@
 import {themes as prismThemes} from 'prism-react-renderer';
 
 const url = process.env.DOCUSAURUS_URL || 'https://magma.github.io'
-const baseUrl = process.env.DOCUSAURUS_BASE_URL || '/'
+const baseUrl = process.env.DOCUSAURUS_BASE_URL || '/magma-documentation/'
 
 // Security note on visibility of this secret in the source code: the API key is
 // not secured by secrecy. It is secured by a referer check for magma.github.io


### PR DESCRIPTION
## Summary

- Set default `baseUrl` to `/magma-documentation/` to match GitHub Pages project site URL structure (`magma.github.io/magma-documentation/`)
- The `DOCUSAURUS_BASE_URL` env var can still override it for other deployment targets

## Context

GitHub Pages serves project repositories at `/<repo-name>/`. The previous default of `/` caused assets and internal links to resolve incorrectly when deployed to `magma.github.io/magma-documentation/`.

## Test plan

- [ ] Verify assets (CSS, images, JS) load correctly at `magma.github.io/magma-documentation/`
- [ ] Verify internal navigation links work
- [ ] Verify local dev (`docker compose up dev`) still works (uses env var override or `/` fallback)