### PR TITLE
docs: remove Vagrant documentation and add deprecation notice

### DIFF
--- a/docusaurus/docs/basics/prerequisites.md
+++ b/docusaurus/docs/basics/prerequisites.md
@@ -15,16 +15,15 @@ Install the following tools:
 
 1. [Docker](https://www.docker.com) and Docker Compose
 2. [Homebrew](https://brew.sh/) *only* for MacOS users
-3. [VirtualBox](https://www.virtualbox.org/)
-3. [Vagrant](https://vagrantup.com)
 
 Replace `brew` with your OS-appropriate package manager as necessary:
 
 ```bash
 brew install python3
 pip3 install ansible fabric3 jsonpickle requests PyYAML
-vagrant plugin install vagrant-vbguest
 ```
+
+> **Note**: Vagrant-based development has been deprecated. Please use the Docker-based AGW deployment instead.
 
 If you are on MacOS, you should start Docker for Mac and increase the memory
 allocation for the Docker engine to at least 4GB (Preferences -> Advanced).

--- a/docusaurus/docs/basics/quick_start_guide.md
+++ b/docusaurus/docs/basics/quick_start_guide.md
@@ -12,35 +12,31 @@ installing Magma for a production deployment.
 
 With the [prereqs](prerequisites.md) installed, we can now set up a minimal
 end-to-end system on your development environment. In this guide, we'll start
-by running the LTE access gateway and orchestrator cloud, and then
+by running the LTE access gateway (via Docker) and orchestrator cloud, and then
 register your local access gateway with your local cloud for management.
 
-We will be spinning up a virtual machine and some docker containers for this
-full setup, so you'll probably want to do this on a system with at least 8GB
-of memory. Our development VM's are in the 192.168.80.0/24 address space, so
-make sure that you don't have anything running which hijacks that (e.g. VPN).
+> **Note**: Vagrant-based development has been deprecated. Please use the
+> Docker-based AGW deployment. See the [AGW Docker deployment guide](../deployment/agw/docker.md)
+> for the latest instructions.
 
-In the following steps, note the prefix in terminal commands. `HOST` means to
-run the indicated command on your host machine, and `MAGMA-VM` on the `magma`
-vagrant machine under `lte/gateway`.
+We will be spinning up docker containers for this full setup, so you'll
+probably want to do this on a system with at least 8GB of memory.
 
 ## Provisioning the environment
 
-Go ahead and open up 2 fresh terminal tabs. Start in
+Go ahead and open up 2 fresh terminal tabs.
 
-### Terminal Tab 1: Provision the AGW VM
+### Terminal Tab 1: Provision the AGW (Docker)
 
-The development environment virtualizes the access gateway so you don't need
-any production hardware on hand to test an end-to-end setup.
-We'll be setting up the LTE AGW VM in this tab.
+The development environment can use Docker to run the Access Gateway. See the
+[AGW Docker deployment](../deployment/agw/docker.md) for detailed instructions.
+
+For quick setup:
 
 ```bash
-HOST [magma]$ cd lte/gateway
-HOST [magma/lte/gateway]$ vagrant up magma
+HOST [magma]$ cd lte/gateway/deploy
+HOST [magma/lte/gateway/deploy]$ ./agw_docker_install.sh
 ```
-
-This will take a few minutes to spin up the VM. While that runs, switch over
-to...
 
 ### Terminal Tab 2: Build Orchestrator
 
@@ -51,38 +47,12 @@ HOST [magma]$ cd orc8r/cloud/docker
 HOST [magma/orc8r/cloud/docker]$ ./build.py -a
 ```
 
-This will build all the docker images for Orchestrator. The `vagrant up` from
-the first tab should finish before the image building, so you should switch
-to that tab and move on for now.
-
 ## Initial Run
-
-Once `vagrant up` in the first tab finishes:
-
-### Terminal Tab 1: Build AGW from Source
-
-We will kick off the initial build of the AGW from source here.
-
-```bash
-HOST [magma/lte/gateway]$ vagrant ssh magma
-MAGMA-VM [/home/vagrant]$ cd magma/lte/gateway
-MAGMA-VM [/home/vagrant/magma/lte/gateway]$ make run
-```
-
-This will take a while (we have a lot of CXX files to build). With 2 extensive
-build jobs running, now is a good time to grab a coffee or lunch. The first
-build ever from source will take a while, but afterwards, a persistent ccache
-and Docker's native layer caching will speed up subsequent builds
-significantly.
-
-You can monitor what happens in the other tab now:
 
 ### Terminal Tab 2: Start Orchestrator
 
 Once the Orchestrator build finishes, we can start the development Orchestrator
-cloud for the first time. We'll also use this time to register the local
-client certificate you'll need to access the local API gateway for your
-development stack.
+cloud for the first time.
 
 Starting Orchestrator is as simple as:
 
@@ -123,31 +93,23 @@ installed client certificates. See [here](https://support.globalsign.com/custome
 for instructions. If you use Chrome or Safari, you may have to restart the
 browser before the certificate can be used.
 
-### Connecting Your Local LTE Gateway to Your Local Cloud
+### Register Your AGW with Orchestrator
 
-At this point, you will have built all the code in the LTE access gateway and
-the Orchestrator cloud. All the services on the LTE access gateway and
-orchestrator cloud are running, but your gateway VM isn't yet set up to
-communicate with your local cloud.
-
-We have a fabric command set up to do this:
+Register your Docker-based AGW with Orchestrator:
 
 ```bash
 HOST [magma]$ cd lte/gateway
-HOST [magma/lte/gateway]$ fab -f dev_tools.py register_vm
+HOST [magma/lte/gateway]$ fab -f dev_tools.py register_agw
 ```
 
-This command will seed your gateway and network on Orchestrator with some
-default LTE configuration values and set your gateway VM up to talk to your
-local Orchestrator cloud. Wait a minute or 2 for the changes to propagate,
-then you can verify that things are working:
+Wait a minute or 2 for the changes to propagate, then you can verify that things are working:
 
 ```bash
-HOST [magma/lte/gateway]$ vagrant ssh magma
+HOST [magma/lte/gateway]$ docker exec -it magma_control /bin/bash
 
-MAGMA-VM$ sudo service magma@* stop
-MAGMA-VM$ sudo service magma@magmad restart
-MAGMA-VM$ sudo tail -f /var/log/syslog
+MAGMA-CONTROL$ sudo service magma@* stop
+MAGMA-CONTROL$ sudo service magma@magmad restart
+MAGMA-CONTROL$ sudo tail -f /var/log/syslog
 
 # After a minute or 2 you should see these messages:
 Sep 27 22:57:35 magma-dev magmad[6226]: [2018-09-27 22:57:35,550 INFO root] Checkin Successful!
@@ -172,6 +134,7 @@ After this, you will be able to access the UI by visiting
 and password `password1234`. If you see Gateway Error 502, don't worry, the
 NMS can take upto 60 seconds to finish starting up.
 
+## Additional Resources
 
-
-
+- For detailed AGW Docker deployment, see [AGW Docker deployment guide](../deployment/agw/docker.md)
+- For testing LTE features without cloud-based network management, see [S1AP integration tests](../lte/s1ap_tests.md)

--- a/readmes/basics/introduction.md
+++ b/readmes/basics/introduction.md
@@ -64,6 +64,15 @@ Magma leverages a variety of modern technologies to implement its solutions:
     - The main programming languages used in development.
     - Multiple language equals multiple opportunities to contribute.
 
+## Deployment Methods
+
+Magma supports multiple deployment methods for the Access Gateway (AGW):
+
+- **Docker-based AGW** (Recommended): The modern, containerized approach for development and production. See the [AGW Docker deployment guide](./deployment/agw/docker.md).
+- **Bare Metal**: For production deployments on physical hardware.
+
+> **Deprecation Notice**: Vagrant-based AGW deployment has been **deprecated** and will be removed in a future release. Please migrate to the Docker-based deployment method.
+
 ## Community
 
 Join the [Magma Slack channel](https://join.slack.com/t/magmacore/shared_invite/zt-g76zkofr-g6~jYiS3KRzC9qhAISUC2A) and interact with our active community.

--- a/readmes/basics/prerequisites.md
+++ b/readmes/basics/prerequisites.md
@@ -27,8 +27,6 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
 
    1. [Docker and Docker Compose](https://docs.docker.com/desktop/install/mac-install/)
    2. [Homebrew](https://brew.sh/)
-   3. [VirtualBox](https://www.virtualbox.org/)
-   4. [Vagrant](https://vagrantup.com)
 
    ```bash
    brew install go@1.20 pyenv
@@ -42,7 +40,6 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
    pyenv install 3.8.10
    pyenv global 3.8.10
    pip3 install ansible fabric jsonpickle requests PyYAML
-   vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-reload
    ```
 
    **Note**: In the case where installation of `fabric` through pip was unsuccessful,
@@ -59,8 +56,6 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
 
 1. Install the following tools
    1. [Docker and Docker Compose](https://docs.docker.com/engine/install/ubuntu/)
-   2. [VirtualBox](https://www.virtualbox.org/wiki/Linux_Downloads)
-   3. [Vagrant](https://www.vagrantup.com/downloads)
 2. Install golang version 1.20.1.
 
    1. Download the tar file.
@@ -146,14 +141,6 @@ Development can occur from multiple OS's, where **macOS** and **Ubuntu** are **e
       ```bash
       pip3 install ansible fabric jsonpickle requests PyYAML
       ```
-
-5. Install `vagrant` necessary plugin.
-
-   ```bash
-   vagrant plugin install vagrant-vbguest vagrant-disksize vagrant-reload
-   ```
-
-    Make sure `virtualbox` is the default provider for `vagrant` by adding the following line to your `.bashrc` (or equivalent) and restart your shell: `export VAGRANT_DEFAULT_PROVIDER="virtualbox"`.
 
 ## Downloading Magma
 

--- a/readmes/basics/quick_start_guide.md
+++ b/readmes/basics/quick_start_guide.md
@@ -11,46 +11,28 @@ installing Magma for a production deployment.
 
 With the [prereqs](prerequisites.md) installed, we can now set up a minimal
 end-to-end system on your development environment. In this guide, we'll start
-by running the LTE access gateway and orchestrator cloud, and then
+by running the LTE access gateway (via Docker) and orchestrator cloud, and then
 register your local access gateway with your local cloud for management.
 
-We will be spinning up a virtual machine and some docker containers for this
-full setup, so you'll probably want to do this on a system with at least 8GB
-of memory. Our development VM's are in the 192.168.60.0/24, 192.168.128.0/24 and
-192.168.129.0/24 address spaces, so make sure that you don't have anything
-running which hijacks those (e.g. VPN).
-
-In the following steps, note the prefix in terminal commands. `HOST` means to
-run the indicated command on your host machine, and `MAGMA-VM` on the `magma`
-vagrant machine under `lte/gateway`.
+> **Note**: Vagrant-based development has been deprecated. Please use the
+> Docker-based AGW deployment. See the [AGW Docker deployment guide](../deployment/agw/docker.md)
+> for the latest instructions.
 
 ## Provisioning the environment
 
-Go ahead and open up 2 fresh terminal tabs. Start in
+Go ahead and open up 2 fresh terminal tabs.
 
-### Terminal Tab 1: Provision the AGW VM
+### Terminal Tab 1: Provision the AGW (Docker)
 
-The development environment virtualizes the access gateway, so you don't need
-any production hardware on hand to test an end-to-end setup.
-We'll be setting up the LTE AGW VM in this tab.
+The development environment can use Docker to run the Access Gateway. See the
+[AGW Docker deployment](../deployment/agw/docker.md) for detailed instructions.
 
-You need to make sure that your local network setup is correct for the VM to
-start properly. Especially the entries `* 192.168.0.0/16` and `* 3001::/64` must exist in your
-`/etc/vbox/networks.conf`.
+For quick setup:
 
 ```bash
-HOST [magma]$ echo "* 192.168.0.0/16" | sudo tee -a /etc/vbox/networks.conf
-HOST [magma]$ echo "* 3001::/64" | sudo tee -a /etc/vbox/networks.conf
-HOST [magma]$ cd lte/gateway
-HOST [magma/lte/gateway]$ vagrant up magma
+HOST [magma]$ cd lte/gateway/deploy
+HOST [magma/lte/gateway/deploy]$ ./agw_docker_install.sh
 ```
-
-This will take a few minutes to spin up the VM. While that runs, switch over
-to...
-
-**Note**: If you are looking to test/develop the LTE features of AGW, without
-cloud based network management, you can skip the rest of this guide and try the
-[S1AP integration tests](../lte/s1ap_tests.md) now.
 
 ### Terminal Tab 2: Build Orchestrator
 
@@ -61,43 +43,14 @@ HOST [magma]$ cd orc8r/cloud/docker
 HOST [magma/orc8r/cloud/docker]$ ./build.py --all
 ```
 
-This will build all the docker images for Orchestrator. The `vagrant up` from
-the first tab should finish before the image building, so you should switch
-to that tab and move on for now.
-
 ## Initial Run
-
-Once `vagrant up` in the first tab finishes:
-
-### Terminal Tab 1: Build AGW from Source
-
-We will kick off the initial build of the AGW from source here.
-
-```bash
-HOST [magma/lte/gateway]$ vagrant ssh magma
-MAGMA-VM [/home/vagrant]$ cd $MAGMA_ROOT && bazel/scripts/build_and_run_bazelified_agw.sh
-```
-
-**Note**: If you encounter unexpected errors during this process, try running
-`vagrant provision magma` in the host environment for more debugging
-information.
-
-This will take a while (we have a lot of CXX files to build). With 2 extensive
-build jobs running, now is a good time to grab a coffee or lunch. The first
-build ever from source will take a while, but afterwards, a persistent Bazel
-cache and Docker's native layer caching will speed up subsequent builds
-significantly.
-
-You can monitor what happens in the other tab now:
 
 ### Terminal Tab 2: Start Orchestrator
 
 Once the Orchestrator build finishes, we can start the development Orchestrator
-cloud for the first time. We'll also use this time to register the local
-client certificate you'll need to access the local API gateway for your
-development stack.
+cloud for the first time.
 
-To start Orchestrator (without metrics) is as simple as:
+To start Orchestrator (without metrics):
 
 ```bash
 HOST [magma/orc8r/cloud/docker]$ ./run.py
@@ -116,19 +69,6 @@ If you want to run everything, including metrics, run:
 
 ```bash
 HOST [magma/orc8r/cloud/docker]$ ./run.py --metrics
-
-Creating orc8r_alertmanager_1     ... done
-Creating orc8r_maria_1            ... done
-Creating elasticsearch            ... done
-Creating orc8r_postgres_1         ... done
-Creating orc8r_config-manager_1   ... done
-Creating orc8r_test_1             ... done
-Creating orc8r_prometheus-cache_1 ... done
-Creating orc8r_prometheus_1       ... done
-Creating orc8r_kibana_1           ... done
-Creating fluentd                  ... done
-Creating orc8r_proxy_1            ... done
-Creating orc8r_controller_1       ... done
 ```
 
 The Orchestrator application containers will bootstrap certificates on startup
@@ -174,36 +114,27 @@ Note that your browser may refuse to accept the server certificate from
 `localhost:9443`. Firefox and Safari will let you override this warning. Chrome
 will also let you [bypass the warning if you type `thisisunsafe`](https://www.technipages.com/google-chrome-bypass-your-connection-is-not-private-message).
 
-### Connecting Your Local LTE Gateway to Your Local Cloud
+### Register Your AGW with Orchestrator
 
-At this point, you will have built all the code in the LTE access gateway and
-the Orchestrator cloud. All the services on the LTE access gateway and
-orchestrator cloud are running, but your gateway VM isn't yet set up to
-communicate with your local cloud.
-
-We have a fabric command set up to do this:
+Register your Docker-based AGW with Orchestrator:
 
 ```bash
 HOST [magma]$ cd lte/gateway
-HOST [magma/lte/gateway]$ fab register-vm
+HOST [magma/lte/gateway]$ fab register-agw
 ```
 
-This command will seed your gateway and network on Orchestrator with some
-default LTE configuration values and set your gateway VM up to talk to your
-local Orchestrator cloud. Wait a minute or 2 for the changes to propagate,
-then you can verify that things are working:
+Wait a minute or 2 for the changes to propagate, then you can verify that things are working:
 
 ```bash
-HOST [magma/lte/gateway]$ vagrant ssh magma
+HOST [magma/lte/gateway]$ docker exec -it magma_control /bin/bash
 
-MAGMA-VM$ sudo service magma@* stop
-MAGMA-VM$ sudo service magma@magmad start
-MAGMA-VM$ sudo tail -f /var/log/syslog
+MAGMA-CONTROL$ sudo service magma@* stop
+MAGMA-CONTROL$ sudo service magma@magmad start
+MAGMA-CONTROL$ sudo tail -f /var/log/syslog
 
 # After a minute or 2 you should see these messages:
 Sep 27 22:57:35 magma-dev magmad[6226]: [2018-09-27 22:57:35,550 INFO root] Checkin Successful!
 Sep 27 22:57:55 magma-dev magmad[6226]: [2018-09-27 22:57:55,684 INFO root] Processing config update g1
-Sep 27 22:57:55 magma-dev control_proxy[6418]: 2018-09-27T22:57:55.683Z [127.0.0.1 -> streamer-controller.magma.test,8443] "POST /magma.Streamer/GetUpdates HTTP/2" 200 7bytes 0.009s
 ```
 
 ## Using the NMS UI
@@ -228,8 +159,8 @@ Note that you will only see a network if you connected your local LTE gateway as
 Organizations are managed at [host.localhost](https://host.localhost)
 where you can log in with the same credentials.
 
-**Note**: If you want to test the access gateway VM with a physical eNB and UE,
-refer to
-the [Connecting a physical eNodeb and UE device to gateway
-VM](../lte/dev_notes.md#connecting-a-physical-enodeb-and-ue-to-gateway-vm)
-section.
+## Additional Resources
+
+- For detailed AGW Docker deployment, see [AGW Docker deployment guide](../deployment/agw/docker.md)
+- For testing LTE features without cloud-based network management, see [S1AP integration tests](../lte/s1ap_tests.md)
+- For connecting a physical eNB and UE device, see the [Connecting a physical eNodeb and UE device to gateway](../lte/dev_notes.md#connecting-a-physical-enodeb-and-ue-to-gateway-vm) section.


### PR DESCRIPTION
- Removed Vagrant and VirtualBox from prerequisites (macOS and Ubuntu)
- Replaced Vagrant-based AGW setup with Docker-based deployment
- Added deprecation notice in introduction.md directing users to Docker
- Updated quick_start_guide.md to use agw_docker_install.sh
- Part of Issue #45: Remove Vagrant Documentation from Magma Documentation Repository

See: magma/magma#15754

<!--
    Tag your PR title with the components that it touches along with
    the type of change
    E.g. "fix(docussaurus): spanish content configuration" or "feat(docker) ..."
-->

## Summary

<!-- Enumerate changes you made and why you made them -->

## Test Plan

<!--
    How did you test your change? How do you know it works?
    Add supporting screenshots, terminal pastes, etc. as necessary
-->

## Additional Information

- [ ] This change is backwards-breaking

<!--
    If this is a backwards-breaking change, document the upgrade instructions.
    Is any action necessary to upgrade an existing instance other than restarting?
    All upgrade instructions for backwards-breaking changes will be aggregated
    in the next release's changelog so this is very important to fill out.
-->

## Security Considerations

<!--
    Comment on potential security impact. Could the change create or 
    eliminate weaknesses? STRIDE, OWASP Top 10, or RFC 3552 may help.
-->

