### PR TITLE
chore(docusaurus): bump Docusaurus from 3.9.2 to ^3.10.0

### DIFF
--- a/docusaurus/package.json
+++ b/docusaurus/package.json
@@ -17,9 +17,9 @@
     "check-links": "lychee ./build/**/*.html --exclude-mail --exclude './**/proposal/**'"
   },
   "dependencies": {
-    "@docusaurus/core": "3.9.2",
-    "@docusaurus/preset-classic": "3.9.2",
-    "@docusaurus/theme-mermaid": "3.9.2",
+    "@docusaurus/core": "^3.10.0",
+    "@docusaurus/preset-classic": "^3.10.0",
+    "@docusaurus/theme-mermaid": "^3.10.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "prism-react-renderer": "^2.3.0",
@@ -27,8 +27,8 @@
     "react-dom": "^18.2.0"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "3.9.2",
-    "@docusaurus/types": "3.9.2"
+    "@docusaurus/module-type-aliases": "^3.10.0",
+    "@docusaurus/types": "^3.10.0"
   },
   "browserslist": {
     "production": [


### PR DESCRIPTION
## Summary
Docusaurus 3.9.2's bundled webpack passed a `name`, `color`, `eporters`, and `reporter` options object to webpack's ProgressPlugin, which failed schema validation and crashed the dev server on startup (docker compose up dev) with:

```bash
  ValidationError: Invalid options object. Progress Plugin has been
  initialized using an options object that does not match the API schema.
```
**Upgrading @docusaurus/core, @docusaurus/preset-classic, @docusaurus/theme-mermaid, @docusaurus/module-type-aliases, and @docusaurus/types to ^3.10.0 resolves this natively.**

## Test Plan
- Confirmed the dev server starts successfully and serves on `http://localhost:3000` without the previous `ValidationError: Invalid options object` ProgressPlugin crash.

## Additional Information

- [ ] This change is backwards-breaking

