### PR TITLE
ci: add Dependabot config for monthly dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    directory: /docusaurus
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: npm
+    directory: /docusaurus
+    schedule:
+      interval: monthly
+    groups:
+      npm:
+        patterns:
+          - "*"


### PR DESCRIPTION
Add `.github/dependabot.yml` so CI/build dependencies stay current.

## What
**Monthly** schedule, grouped per ecosystem to keep PR noise low:
- `github-actions` — action versions in `.github/workflows/`
- `docker` — the `node:24-slim` base in `docusaurus/Dockerfile`
- `npm` — Docusaurus dependencies in `docusaurus/`

## Manual trigger
Maintainers can run an update check on demand without waiting for the monthly run: **Insights → Dependency graph → Dependabot → "Check for updates"**, or `@dependabot` comment commands on a Dependabot PR.

## Why
Nothing currently updates action tags automatically (only Dependabot *security* fixes are enabled); several actions are a couple of majors behind. This adds routine version updates on a low-noise monthly cadence.