### PR TITLE
ci: run docs-fix via Docker and track its Node version with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,11 @@ updates:
     schedule:
       interval: monthly
 
+  - package-ecosystem: docker
+    directory: /readmes
+    schedule:
+      interval: monthly
+
   - package-ecosystem: npm
     directory: /docusaurus
     schedule:

--- a/.github/workflows/docs-fix.yml
+++ b/.github/workflows/docs-fix.yml
@@ -29,20 +29,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: '18'
-
-      - name: Setup Python (if needed)
-        uses: actions/setup-python@v6
-        with:
-          python-version: '3.8'
-
-      - name: Install deps
-        run: yarn install --frozen-lockfile
-
-      - name: Run precommit fix
+      - name: Run docs auto-fix
         run: make -C readmes precommit_fix
 
       - name: Show diff after fix

--- a/readmes/Dockerfile
+++ b/readmes/Dockerfile
@@ -9,7 +9,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM node:20.16
+FROM node:26-slim
 
 RUN mkdir -p /readmes
 WORKDIR /readmes


### PR DESCRIPTION
## What
Make the `docs-fix` workflow fully Docker-based and put its Node version under Dependabot.

- **docs-fix.yml**: drop the runner-native `setup-node@18`, `setup-python`, and `yarn install` steps. They were redundant (the fix already runs markdownlint inside `readmes/Dockerfile`) and broken (`yarn install` ran at the repo root, which has no `package.json`). The job is now: checkout -> `make -C readmes precommit_fix` (Dockerized) -> capture/upload the patch.
- **readmes/Dockerfile**: `node:20.16` -> `node:26-slim`, aligning with the docusaurus image.
- **dependabot.yml**: add a `docker` entry for `/readmes` so the markdownlint image Node version is bumped automatically.

## Why
A `node-version:` workflow input is not updated by Dependabot (it tracks `uses:` tags and Dockerfile `FROM`, not action inputs) — which is why it sat at 18. Pinning Node in a Dockerfile and tracking that directory keeps it maintainable.

## Validation
Built `readmes/Dockerfile` on `node:26-slim`; `markdownlint --version` -> 0.48.0 (tooling works on Node 26).