### PR TITLE
Docs: Fix the orc8r stale references to broken paths

### DIFF
--- a/docusaurus/create_docusaurus_website.sh
+++ b/docusaurus/create_docusaurus_website.sh
@@ -50,4 +50,4 @@ echo 'If you want to follow the build logs, run docker compose logs -f docusauru
 spin
 echo 'Navigate to http://localhost:3000/ to see the docs.'
 
-xdg-open 'http://localhost:3000/docs/next/basics/introduction.html' || true
+xdg-open 'http://localhost:3000/' || true

--- a/readmes/orc8r/deploy_install.md
+++ b/readmes/orc8r/deploy_install.md
@@ -136,7 +136,7 @@ override the following parameters
 - `orc8r_db_engine_version` on fresh Orc8r installs, target Postgres `12.6`
 
 Make sure that the `source` variables for the module definitions point to
-`github.com/magma/magma//orc8r/cloud/deploy/terraform/MODULE?ref=v1.9`.
+`github.com/magma/magma/tree/v1.9/orc8r/cloud/deploy/terraform/`.
 Adjust any other parameters as you see fit. Check the READMEs for the
 relevant Terraform modules to see additional variables that can be set.
 You can [override values](./deploy_terraform_options.md#override-terraform-module-values)
@@ -236,7 +236,7 @@ Create the Orchestrator admin user with the `admin_operator` certificate
 created earlier
 
 ```bash
-kubectl --namespace orc8r exec deploy/orc8r-orchestrator -- \
+kubectl --namespace orc8r exec -it deploy/orc8r-orchestrator -- \
   /var/opt/magma/bin/accessc \
   add-existing -admin -cert /var/opt/magma/certs/admin_operator.pem \
   admin_operator
@@ -246,7 +246,7 @@ If you want to verify the admin user was successfully created, inspect the
 output from
 
 ```bash
-$ kubectl --namespace orc8r exec deploy/orc8r-orchestrator -- \
+$ kubectl --namespace orc8r exec -it deploy/orc8r-orchestrator -- \
   /var/opt/magma/bin/accessc list-certs
 
 # NOTE: actual values will differ

--- a/readmes/orc8r/deploy_intro.md
+++ b/readmes/orc8r/deploy_intro.md
@@ -69,7 +69,7 @@ Values for recent Orchestrator releases are summarized below
 Verified with Terraform version `1.0.11`.
 
 - `v1.9` [patch branch](https://github.com/magma/magma/tree/v1.9)
-- `github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.9`
+- `github.com/magma/magma/tree/v1.9/orc8r/cloud/deploy/terraform/orc8r-aws`
 Terraform module source
 - `1.9.0` Helm chart version
 
@@ -78,7 +78,7 @@ Terraform module source
 Verified with Terraform version `1.0.11`.
 
 - `v1.8` [patch branch](https://github.com/magma/magma/tree/v1.8)
-- `github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.8`
+- `github.com/magma/magma/tree/v1.8/orc8r/cloud/deploy/terraform/orc8r-aws`
 Terraform module source
 - `1.8.0` Helm chart version
 
@@ -87,7 +87,7 @@ Terraform module source
 Verified with Terraform version `0.15.0`.
 
 - `v1.6` [patch branch](https://github.com/magma/magma/tree/v1.6)
-- `github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.6`
+- `github.com/magma/magma/tree/v1.6/orc8r/cloud/deploy/terraform/orc8r-aws`
 Terraform module source
 - `1.5.23` Helm chart version
 - Additional notes
@@ -98,7 +98,7 @@ Terraform module source
 Verified with Terraform version `0.14.5`. Terraform `0.15.x` is *not* compatible.
 
 - `v1.5` [patch branch](https://github.com/magma/magma/tree/v1.5)
-- `github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.5`
+- `github.com/magma/magma/tree/v1.5/orc8r/cloud/deploy/terraform/orc8r-aws`
 Terraform module source
 - `1.5.21` Helm chart version
 - Additional notes
@@ -109,7 +109,7 @@ Terraform module source
 Verified with Terraform version `0.14.0`.
 
 - `v1.4` [patch branch](https://github.com/magma/magma/tree/v1.4)
-- `github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.4`
+- `github.com/magma/magma/tree/v1.4/orc8r/cloud/deploy/terraform/orc8r-aws`
 Terraform module source
 - `1.5.16` Helm chart version
 - Additional notes
@@ -120,7 +120,7 @@ Terraform module source
 Verified with Terraform version `0.13.1`.
 
 - `v1.3` [patch branch](https://github.com/magma/magma/tree/v1.3)
-- `github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.3`
+- `github.com/magma/magma/tree/v1.3/orc8r/cloud/deploy/terraform/orc8r-aws`
 Terraform module source
 - `1.4.36` Helm chart version
 - Additional notes
@@ -131,7 +131,7 @@ Terraform module source
 Verified with Terraform version `0.13.1`.
 
 - `v1.2` [patch branch](https://github.com/magma/magma/tree/v1.2)
-- `github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.2`
+- `github.com/magma/magma/tree/v1.2/orc8r/cloud/deploy/terraform/orc8r-aws`
 Terraform module source
 - `1.4.35` Helm chart version
 - Additional notes
@@ -142,7 +142,7 @@ Terraform module source
 Verified with Terraform version `0.12.29`.
 
 - `v1.1` [patch branch](https://github.com/magma/magma/tree/v1.1)
-- `github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.1`
+- `github.com/magma/magma/tree/v1.1/orc8r/cloud/deploy/terraform/orc8r-aws`
 Terraform module source
 - `1.4.21` Helm chart version
 - Additional notes

--- a/readmes/orc8r/deploy_using_ansible.md
+++ b/readmes/orc8r/deploy_using_ansible.md
@@ -25,7 +25,7 @@ For more information on Magma Deployer, please visit the project's
 Quick Install:
 
 ```bash
-sudo bash -c "$(curl -sL https://raw.githubusercontent.com/magma/magma-deployer/refs/heads/main/orc8r-deployer/deploy-orc8r.sh)"
+sudo bash -c "$(curl -sL https://raw.githubusercontent.com/magma/magma-deployer/main/orc8r-deployer/deploy-orc8r.sh)"
 ```
 
 Following roles will be installed:
@@ -113,7 +113,7 @@ postgresql-0                                    1/1     Running   0          12m
 Now setup NMS login:
 
 ```bash
-cd ~/magma-deployer
+cd ~/magma-deployer/orc8r-deployer
 ansible-playbook config-orc8r.yml
 ```
 

--- a/readmes/orc8r/upgrade_1_1.md
+++ b/readmes/orc8r/upgrade_1_1.md
@@ -24,9 +24,7 @@ First, create a new directory somewhere to store your new root Terraform module
 for the 1.1.x deployment. We have an example root module at \<https://github.com/facebookincubator/magma/tree/v1.1/orc8r/cloud/deploy/terraform/orc8r-helm-aws/examples/online-upgrade\>
 that we recommend you use for the upgrade. Copy all the files to your new
 directory and change the `source` attribute of both modules in `main.tf` to
-`github.com/facebookincubator/magma//orc8r/cloud/deploy/terraform/orc8r-aws` and
-`github.com/facebookincubator/magma//orc8r/cloud/deploy/terraform/orc8r-helm-aws`,
-respectively.
+`https://github.com/facebookincubator/magma/tree/v1.0.0/orc8r/cloud/deploy/terraform`
 
 Once you've got this root module set up and your variables defined, run
 `terraform init` in this directory.

--- a/readmes/orc8r/upgrade_1_2.md
+++ b/readmes/orc8r/upgrade_1_2.md
@@ -129,12 +129,12 @@ First, update your `main.tf` file to pull in the v1.2 changes
 
 ```hcl-terraform
 module orc8r {
-  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.2"
+  source = "github.com/magma/magma/tree/v1.2.0/orc8r/cloud/deploy/terraform/orc8r-aws"
   # ...
 }
 
 module orc8r-app {
-  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-helm-aws?ref=v1.2"
+  source = "github.com/magma/magma/tree/v1.2.0/orc8r/cloud/deploy/terraform/orc8r-helm-aws"
   # ...
   orc8r_chart_version = "1.4.35"
   orc8r_tag           = "MAGMA_TAG"  # from build step

--- a/readmes/orc8r/upgrade_1_3.md
+++ b/readmes/orc8r/upgrade_1_3.md
@@ -36,12 +36,12 @@ container versions:
 
 ```hcl-terraform
 module orc8r {
-  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.3"
+  source = "github.com/magma/magma/tree/v1.3.0/orc8r/cloud/deploy/terraform/orc8r-aws"
   # ...
 }
 
 module orc8r-app {
-  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-helm-aws?ref=v1.3"
+  source = "github.com/magma/magma/tree/v1.3.0/orc8r/cloud/deploy/terraform/orc8r-helm-aws"
   # ...
   orc8r_chart_version = "1.4.36"
   orc8r_tag           = "MAGMA_TAG"  # from build step, e.g. v1.3.0

--- a/readmes/orc8r/upgrade_1_4.md
+++ b/readmes/orc8r/upgrade_1_4.md
@@ -48,13 +48,13 @@ container versions
 # This will likely be found in main.tf
 
 module orc8r {
-  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.4"
+  source = "github.com/magma/magma/tree/v1.4.0/orc8r/cloud/deploy/terraform/orc8r-aws"
   # ...
   cluster_version = "1.17"   # set to Kubernetes version found above. 1.17 is used as an example here
 }
 
 module orc8r-app {
-  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-helm-aws?ref=v1.4"
+  source = "github.com/magma/magma/tree/v1.4.0/orc8r/cloud/deploy/terraform/orc8r-helm-aws"
   # ...
   orc8r_chart_version   = "1.5.16"
   orc8r_tag             = "MAGMA_TAG"  # from build step, e.g. v1.4.0

--- a/readmes/orc8r/upgrade_1_5.md
+++ b/readmes/orc8r/upgrade_1_5.md
@@ -65,7 +65,7 @@ This process prepares your cluster for Orc8r-NMS DB unification. (In release 1.5
 *Paste in shell prompt:*
 
 ```bash
-wget https://raw.githubusercontent.com/magma/magma/v1.5/nms/app/packages/magmalte/scripts/fuji-upgrade/pre-upgrade-migration.sh && chmod +x pre-upgrade-migration.sh && ./pre-upgrade-migration.sh
+wget https://raw.githubusercontent.com/magma/magma/v1.5.0/nms/app/packages/magmalte/scripts/fuji-upgrade/pre-upgrade-migration.sh && chmod +x pre-upgrade-migration.sh && ./pre-upgrade-migration.sh
 ```
 
 The defaults options should likely work, unless the script cannot find the
@@ -96,13 +96,13 @@ container versions
 # This will likely be found in main.tf
 
 module orc8r {
-  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.5"
+  source = "github.com/magma/magma/tree/v1.5.0/orc8r/cloud/deploy/terraform/orc8r-aws"
   # ...
   cluster_version = "1.17"   # set to Kubernetes version found above. 1.17 is used as an example here
 }
 
 module orc8r-app {
-  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-helm-aws?ref=v1.5"
+  source = "github.com/magma/magma/tree/v1.5.0/orc8r/cloud/deploy/terraform/orc8r-helm-aws"
   # ...
   orc8r_chart_version   = "1.5.20"
   orc8r_tag             = "MAGMA_TAG"  # from build step, e.g. v1.5.0

--- a/readmes/orc8r/upgrade_1_6.md
+++ b/readmes/orc8r/upgrade_1_6.md
@@ -35,7 +35,7 @@ Update your root Terraform module
 # This will likely be found in main.tf
 
 module orc8r {
-  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-aws?ref=v1.6"
+  source = "github.com/magma/magma/tree/v1.6.0/orc8r/cloud/deploy/terraform/orc8r-aws"
 
   # Optional: enable AWS DB failure notifications
   # orc8r_sns_email             = "admin@example.com"
@@ -47,7 +47,7 @@ module orc8r {
 module orc8r-app {
   # IMPORTANT: delete all docker_ and helm_ lines
 
-  source = "github.com/magma/magma//orc8r/cloud/deploy/terraform/orc8r-helm-aws?ref=v1.6"
+  source = "github.com/magma/magma/tree/v1.6.0/orc8r/cloud/deploy/terraform/orc8r-helm-aws"
   orc8r_tag = "v1.6.0"
 
   # Optional: prune ES indices when disk usage exceeds 75% of allocated ES storage
@@ -82,4 +82,4 @@ To upgrade your Postgres database to the correct version follow [these instructi
 
 ### Host custom artifacts
 
-If you wish to use your own artifacts, follow the follow the [Build Orchestrator](https://magma.github.io/magma/docs/orc8r/deploy_build) page to build and publish your own artifacts from the [v1.6 branch of the Magma repo](https://github.com/magma/magma/tree/v1.6), then update your `main.tf` file to point to the appropriate artifactories.
+If you wish to use your own artifacts, follow the [Build Orchestrator](https://magma.github.io/magma/docs/orc8r/deploy_build) page to build and publish your own artifacts from the [v1.6 branch of the Magma repo](https://github.com/magma/magma/tree/v1.6.0), then update your `main.tf` file to point to the appropriate artifactories.


### PR DESCRIPTION
## Summary
- update `readmes/orc8r` docs where many URLs were redirecting to `404` pages. New links refer to updated codebase and tags
- based on PR #62 the website made the introduction page as the default homepage, hence updated `create_docusaurus_website.sh` to open `localhost:3000` using `xdg-open`