### PR TITLE
docs(orc8r): improve Minikube deployment guide

### DIFF
--- a/readmes/orc8r/dev_minikube.md
+++ b/readmes/orc8r/dev_minikube.md
@@ -10,6 +10,19 @@ Deploying Orc8r on Minikube is the easiest way to test changes to the Helm chart
 
 ## Prerequisites
 
+We assume MAGMA_ROOT is set as described in [deployment intro](./deploy_intro.md).
+
+### Install Prerequisites
+
+Ensure the following tools are installed on your system:
+
+- **Docker**
+- **kubectl**
+- **Minikube**
+- **Helm 3**
+
+> For kubectl install a version compatible with v1.28.0 (v1.27.x through v1.29.x), matching the cluster version exactly is recommended.
+
 ### Spin up Minikube
 
 Set up Minikube with one of the following commands, including sufficient resources and seeding the metrics config files:
@@ -17,13 +30,13 @@ Set up Minikube with one of the following commands, including sufficient resourc
 - On macOS
 
   ```bash
-  minikube start --cni=bridge --driver=hyperkit --memory=8gb --cpus=8 --kubernetes-version='v1.20.2' --mount --mount-string "${MAGMA_ROOT}/orc8r/cloud/docker/metrics-configs:/configs"
+  minikube start --cni=bridge --driver=hyperkit --memory=8gb --cpus=8 --kubernetes-version='v1.28.0' --mount --mount-string "${MAGMA_ROOT}/orc8r/cloud/docker/metrics-configs:/configs"
   ```
 
 - On Linux
 
   ```bash
-  minikube start --cni=bridge --driver=docker --memory=8gb --cpus=8 --kubernetes-version='v1.20.2' --mount --mount-string "${MAGMA_ROOT}/orc8r/cloud/docker/metrics-configs:/configs"
+  minikube start --cni=bridge --driver=docker --memory=8gb --cpus=8 --kubernetes-version='v1.28.0' --mount --mount-string "${MAGMA_ROOT}/orc8r/cloud/docker/metrics-configs:/configs"
   ```
 
 where the only difference between the two is the driver used.
@@ -44,6 +57,12 @@ helm upgrade --install \
     --set global.postgresql.auth.postgresPassword=postgres,global.postgresql.auth.database=magma,fullnameOverride=postgresql \
     postgresql \
     bitnami/postgresql
+```
+
+Verify postgresql-0 is Running:
+
+```bash
+kubectl --namespace orc8r get pods
 ```
 
 ### Build and publish images
@@ -67,6 +86,14 @@ After completing the prerequisites listed above, follow the instructions at [Bui
 
 ### Generate secrets
 
+Run this before building to pin the dependency versions:
+
+```bash
+for f in ${MAGMA_ROOT}/orc8r/cloud/docker/fluentd/Dockerfile ${MAGMA_ROOT}/orc8r/cloud/docker/fluentd_forward/Dockerfile; do
+  sed -i '/^USER root/a RUN gem install multi_json -v 1.15.0 --no-document\nRUN gem install excon -v 1.2.5 --no-document' "$f"
+done
+```
+
 If you haven't already, the easiest way to generate these secrets is temporarily spinning up a local, Docker-based deployment
 
 ```bash
@@ -75,6 +102,13 @@ cd ${MAGMA_ROOT}/orc8r/cloud/docker && ./build.py && ./run.py && sleep 30 && doc
 ```
 
 ### Apply secrets
+
+Before applying the certificates, grant ownership of the cert files to the current user.
+
+```bash
+export CERTS_DIR=${MAGMA_ROOT}/.cache/test_certs
+sudo chown -R $USER:$USER ${CERTS_DIR}
+```
 
 Create the K8s secrets
 
@@ -107,7 +141,9 @@ helm template orc8r charts/secrets \
 
 ### Optional: fluentd secrets
 
-To use fluentd on the minikube deployment, create additional fluentd secrets
+To use fluentd on the minikube deployment, create additional fluentd secrets :
+
+> Change `$domain` to the same domain as the base orc8r install, we used 'magma.test' in this guide
 
 ```bash
 cd ${CERTS_DIR}
@@ -145,16 +181,30 @@ helm template orc8r charts/secrets \
 
 A minimal values file is at `${MAGMA_ROOT}/orc8r/cloud/helm/orc8r/examples/minikube.values.yaml`
 
-- Copy that file to `${MAGMA_ROOT}/orc8r/cloud/helm/orc8r.values.yaml`
-- Replace `IMAGE_REGISTRY_URL` with your registry and `IMAGE_TAG` with your tag
-- Make additional edits as desired
+Copy that file to `${MAGMA_ROOT}/orc8r/cloud/helm/orc8r.values.yaml`:
+
+```bash
+cp ${MAGMA_ROOT}/orc8r/cloud/helm/orc8r/examples/minikube.values.yaml \
+   ${MAGMA_ROOT}/orc8r/cloud/helm/orc8r.values.yaml
+```
+
+Replace `IMAGE_REGISTRY_URL` with your registry and `IMAGE_TAG` with your tag, or use the official Magma registry :
+
+```bash
+sed -i 's|IMAGE_REGISTRY_URL|linuxfoundation.jfrog.io/magma-docker|g' ${MAGMA_ROOT}/orc8r/cloud/helm/orc8r.values.yaml
+sed -i 's|IMAGE_TAG|1.9.0|g' ${MAGMA_ROOT}/orc8r/cloud/helm/orc8r.values.yaml
+```
+
+> Note:
+>
+> Replace 1.9.0 with the Magma release you are deploying. Check the latest release at [Magma releases](https://github.com/magma/magma/releases).
 
 ### Install charts
 
 This section describes how to install based on local charts. However, you can also install charts from the official chart repositories
 
-- Stable: \<https://linuxfoundation.jfrog.io/artifactory/magma-helm-prod/\>
-- Test: \<https://linuxfoundation.jfrog.io/artifactory/magma-helm-test/\>
+- Stable: https://linuxfoundation.jfrog.io/artifactory/magma-helm-prod
+- Test: https://linuxfoundation.jfrog.io/artifactory/magma-helm-test
 
 Install base `orc8r` chart
 
@@ -299,6 +349,50 @@ cd ${MAGMA_ROOT}/orc8r/cloud/docker
 ./run.py
 ```
 
+### Install LTE chart (Optional)
+
+Additional functionality can be added to Orc8r by installing the corresponding Helm charts. This section demonstrates the process using the LTE chart as an example.
+
+**Create the LTE values file :**
+
+```bash
+cp ${MAGMA_ROOT}/lte/cloud/helm/lte-orc8r/examples/minikube.values.yaml \
+   ${MAGMA_ROOT}/orc8r/cloud/helm/lte.values.yaml
+```
+
+Replace `IMAGE_REGISTRY_URL` with your registry and `IMAGE_TAG` with your tag, or use the official Magma registry.
+
+```bash
+sed -i 's|IMAGE_REGISTRY_URL|linuxfoundation.jfrog.io/magma-docker|g' ${MAGMA_ROOT}/orc8r/cloud/helm/orc8r.values.yaml
+sed -i 's|IMAGE_TAG|1.9.0|g' ${MAGMA_ROOT}/orc8r/cloud/helm/orc8r.values.yaml
+```
+
+**Add the domain name field :**
+
+The orc8rlib templates require `orc8r_domain_name`. Add it under the image block in
+`lte-orc8r.values.yaml` (use the same domain as the base orc8r install):
+
+```yaml
+image:
+  env:
+    orc8r_domain_name: "magma.test"
+```
+
+**Install the LTE chart :**
+
+```bash
+cd ${MAGMA_ROOT}/lte/cloud/helm/lte-orc8r
+helm dep update
+helm upgrade --install --namespace orc8r \
+  --values ${MAGMA_ROOT}/orc8r/cloud/helm/lte.values.yaml lte .
+```
+
+**The new LTE pods should appear and reach `Running` state. You can now create an LTE network in the NMS, check the pods state with :**
+
+```bash
+kubectl --namespace orc8r get pods
+```
+
 ### Access logs through Kibana
 
 The Orchestrator logs aggregated by fluentd can be accessed via Kibana in the web browser under `http://localhost:5601/`.
@@ -345,7 +439,7 @@ Start port-forward for Nginx (this tab will hang):
 kubectl --namespace orc8r port-forward svc/nginx-proxy 8081:443
 ```
 
-Log in to NMS at \<https://magma-test.localhost:8081\> using credentials you chose when creating the admin user.
+Log in to NMS at https://magma-test.localhost:8081 using credentials you chose when creating the admin user.
 
 ## Appendix
 


### PR DESCRIPTION
## Context

This PR follows [#16032](https://github.com/magma/magma/pull/16032) and updates the existing Orc8r Minikube deployment guide.

The current documentation uses Kubernetes v1.20, which is no longer supported by modern Minikube releases. The guide has been updated to use Kubernetes v1.28 and to reflect the steps required to deploy Orc8r successfully on a current Minikube environment.

## Summary

This PR improves the Orc8r Minikube deployment guide by:

- Updating the Kubernetes version from v1.20 to v1.28.
- Documenting the compatible kubectl version range.
- Clarifying the required prerequisites.
- Pinning Fluentd Ruby dependency versions to ensure compatible container builds (we can remove this after the PR #15699 get merged).
- Fixing certificate permission issues caused by Docker creating the certificate files as root before applying the certificates.
- Adding an optional LTE chart installation example to demonstrate how additional Orc8r functionality can be deployed.

## Test Plan

Followed the updated guide and validated the deployment on Kubernetes v1.28.0 using Minikube.

Verified that the Orc8r Helm charts can be installed and the required pods reach the `Running` state.

## Additional Information

The Kubernetes v1.28 deployment relies on the Helm chart API updates introduced in [#16032](https://github.com/magma/magma/pull/16032).

## Security Considerations

No security impact.